### PR TITLE
BSRWEB-3666 Make raw_xml of response accessible for debugging

### DIFF
--- a/lib/gillbus/base_response.rb
+++ b/lib/gillbus/base_response.rb
@@ -13,11 +13,15 @@ class Gillbus
     attr_accessor :external_error_message
     attr_accessor :request_time
 
+    attr_accessor :raw_xml # make accessible for logging and debuging
+
     def error?
       !error_code.nil?
     end
 
     def self.parse(data, instance: new, options: {})
+      instance.raw_xml = options[:raw_xml] if options[:raw_xml]
+
       # ugly
       if data['MESSAGE']
         instance.error_code = data['MESSAGE']['CODE'].to_i
@@ -36,7 +40,7 @@ class Gillbus
       # <DATA/> is a valid response
       return ParseError.new(xml_string, 'DATA attribute missing') unless xml.key?('DATA')
       data = xml['DATA'] || {}
-      parse(data, instance: new, options: options)
+      parse(data, instance: new, options: options.merge(raw_xml: xml_string))
     rescue Ox::ParseError, ArgumentError => e
       ParseError.new(xml_string, e.message)
     end

--- a/lib/gillbus/version.rb
+++ b/lib/gillbus/version.rb
@@ -1,3 +1,3 @@
 class Gillbus
-  VERSION = '0.18.9'.freeze
+  VERSION = '0.18.10'.freeze
 end

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -22,7 +22,7 @@ class ErrorTest < Minitest::Test
 
   def test_malformed_errorness
     assert malformed_response.error?
-    assert_equal "Malformed response: invalid format, expected < at line 1, column 1 [parse.c:146]\n", malformed_response.error_message
+    assert_equal "Malformed response: invalid format, expected < at line 1, column 1 [parse.c:147]\n", malformed_response.error_message
   end
 
   def test_malformed_2_errorness


### PR DESCRIPTION
Добавил возможность доступа к `raw_xml` ответа `GDS` для возможности логгирования и отладки