### PR TITLE
Support new trip options format

### DIFF
--- a/lib/gillbus/helpers/parser.rb
+++ b/lib/gillbus/helpers/parser.rb
@@ -40,12 +40,15 @@ class Gillbus
     private
 
     def fetch_value(key:, root:)
+      target_doc = root ? doc[root] : doc
+      return unless target_doc
+
       if key.is_a?(Regexp)
-        doc.select { |k| k =~ key }
-      elsif root
-        doc[root] && doc[root][key]
+        target_doc.select { |k| k =~ key }
+      elsif key.is_a?(Array)
+        key.map { |k| Array(target_doc[k]) }.inject(&:+)
       else
-        doc[key]
+        target_doc[key]
       end
     end
 

--- a/lib/gillbus/helpers/parser.rb
+++ b/lib/gillbus/helpers/parser.rb
@@ -84,6 +84,8 @@ class Gillbus
 
     def string(val)
       return if val == NULL_CONST
+      # если это тег с атрибутами - возвращаем только содержимое тега
+      return val.last if val.is_a?(Array) && val.size == 2
       val
     end
 

--- a/lib/gillbus/structs/trip_options.rb
+++ b/lib/gillbus/structs/trip_options.rb
@@ -3,45 +3,91 @@ class Gillbus
     extend Fields
     include UpdateAttrs
 
-    # услуги на рейсе (Wi-Fi, розетки и т.п.)
-    field :services, [TripService], root: 'TRIP_SERVICES', key: 'TRIP_SERVICE'
+    # Услуги на рейсе (Wi-Fi, розетки и т.п.)
+    field :services, [TripService],
+      root: 'TRIP_SERVICES',
+      key: 'TRIP_SERVICE'
 
-    # условия по багажу на рейсе
-    field :luggage, [:string], root: 'LUGGAGE', key: 'ITEM'
+    # Условия по багажу на рейсе.
+    # Поддерживаются старый и новый форматы:
+    #   <LUGGAGE>
+    #     <ITEM>Text</ITEM>
+    #     <LUGGAG ID="1">Text</LUGGAG>
+    #   </LUGGAGE>
+    field :luggage, [:string],
+      root: 'LUGGAGE',
+      key: ['ITEM', 'LUGGAG']
 
-    # условия рассадки на рейсе
-    field :seating, [:string], root: 'SEATING', key: 'ITEM'
+    # Условия рассадки на рейсе.
+    # Поддерживаются старый и новый форматы:
+    #   <SEATING>
+    #     <ITEM>Text</ITEM>
+    #     <SEATIN ID="1">Text</SEATIN>
+    #   </SEATING>
+    field :seating, [:string],
+      root: 'SEATING',
+      key: ['ITEM', 'SEATIN']
 
-    # информация о технических остановках
-    field :technical_stops, [:string], root: 'TECHNICAL_STOP', key: 'ITEM'
+    # Информация о технических остановках.
+    # Поддерживаются старый и новый форматы:
+    #   <TECHNICAL_STOP>
+    #     <ITEM>Text</ITEM>
+    #     <TECHNICAL_STO ID="1">Text</TECHNICAL_STO>
+    #   </TECHNICAL_STOP>
+    field :technical_stops, [:string],
+      root: 'TECHNICAL_STOP',
+      key: ['ITEM', 'TECHNICAL_STO']
 
-    # критичная информация о рейсе
-    field :critical_info, [:string], root: 'CRITICAL_INFO', key: 'ITEM'
+    # Критичная информация о рейсе.
+    # Поддерживаются старый и новый форматы:
+    #   <CRITICAL_INFO>
+    #     <ITEM>Text</ITEM>
+    #     <CRITICAL_INF ID="1">Text</CRITICAL_INF>
+    #   </CRITICAL_INFO>
+    field :critical_info, [:string],
+      root: 'CRITICAL_INFO',
+      key: ['ITEM', 'CRITICAL_INF']
 
-    # опции полученные от внешних ресурсов
-    field :resource_options, [:string], root: 'RESOURCE_TRIP_OPTION', key: 'ITEM'
+    # Опции полученные от внешних ресурсов.
+    # Поддерживаются старый и новый форматы:
+    #   <RESOURCE_TRIP_OPTION>
+    #     <ITEM>Text</ITEM>
+    #     <RESOURCE_TRIP_OPTIO ID="1">Text</RESOURCE_TRIP_OPTIO>
+    #   </RESOURCE_TRIP_OPTION>
+    field :resource_options, [:string],
+      root: 'RESOURCE_TRIP_OPTION',
+      key: ['ITEM', 'RESOURCE_TRIP_OPTIO']
 
-    # информация, отмеченная как "прочее"
-    field :other, [:string], root: 'OTHER', key: 'ITEM'
+    # Информация, отмеченная как "прочее".
+    # Поддерживаются старый и новый форматы:
+    #   <OTHER>
+    #     <ITEM>Text</ITEM>
+    #     <OTHE ID="1">Text</OTHE>
+    #   </OTHER>
+    field :other, [:string],
+      root: 'OTHER',
+      key: ['ITEM', 'OTHE']
 
-    # признак рекламируемого рейса, передается как <PROMO><ITEM>ADVERTISING</ITEM></PROMO>
-    field :advertising, :adertising_bool, root: 'PROMO', key: 'ITEM'
+    # Поддерживаются старый и новый форматы:
+    #   <PROMO>
+    #     <ITEM>Text</ITEM>
+    #     <PROM ID="1">Text</PROM>
+    #   </PROMO>
+    field :promo, [:string],
+      root: 'PROMO',
+      key: ['ITEM', 'PROM']
 
-    # признак рекомендованого рейса, передается как <PROMO><ITEM>BUSFOR_RECOMMEND</ITEM></PROMO>
-    field :busfor_recommend, :recommend_bool, root: 'PROMO', key: 'ITEM'
+    # Опции, связанные с билетами.
+    field :tickets, [TicketsOption],
+      root: 'TICKETS',
+      key: 'TICKET'
 
-    # опции, связанные с билетами
-    # элемент с ID="7" означает электронный билет
-    field :tickets, [TicketsOption], root: 'TICKETS', key: 'TICKET'
+    def advertising
+      promo.include?('ADVERTISING')
+    end
 
-    parser do # better not to let flag value out of this gem
-      def adertising_bool(vals)
-        vals.include?('ADVERTISING')
-      end
-
-      def recommend_bool(vals)
-        vals.include?('BUSFOR_RECOMMEND')
-      end
+    def busfor_recommend
+      promo.include?('BUSFOR_RECOMMEND')
     end
 
     def self.build_blank

--- a/lib/gillbus/version.rb
+++ b/lib/gillbus/version.rb
@@ -1,3 +1,3 @@
 class Gillbus
-  VERSION = '0.19.1'.freeze
+  VERSION = '0.19.2'.freeze
 end

--- a/lib/gillbus/version.rb
+++ b/lib/gillbus/version.rb
@@ -1,3 +1,3 @@
 class Gillbus
-  VERSION = '0.19.2'.freeze
+  VERSION = '0.20.0'.freeze
 end

--- a/test/responses/searchTrips-new-options-format.xml
+++ b/test/responses/searchTrips-new-options-format.xml
@@ -1,0 +1,243 @@
+<DATA>
+    <COMPLETED>true</COMPLETED>
+    <TRIP>
+        <ID>3451212695530327295</ID>
+        <RES_ID>10</RES_ID>
+        <NUMBER>2197</NUMBER>
+        <START_CITY_NAME>Москва</START_CITY_NAME>
+        <END_CITY_NAME>Санкт-Петербург</END_CITY_NAME>
+        <START_DATE>23.08.2014</START_DATE>
+        <END_DATE>24.08.2014</END_DATE>
+        <START_TIME>19:00</START_TIME>
+        <START_TIMEZONE>Europe/Moscow</START_TIMEZONE>
+        <END_TIME>06:30</END_TIME>
+        <END_TIMEZONE>Europe/Moscow</END_TIMEZONE>
+        <BUS_MODEL/>
+        <PLACES_COUNT>18</PLACES_COUNT>
+        <FREE_PLACES_COUNT>3</FREE_PLACES_COUNT>
+        <FREE_BUSY_PLACES>3/18</FREE_BUSY_PLACES>
+        <CARRIER_NAME>ИП Унанян И.А.</CARRIER_NAME>
+        <TIME_IN_ROAD>11:30</TIME_IN_ROAD>
+        <STATION_BEGIN_NAME>Москва</STATION_BEGIN_NAME>
+        <STATION_BEGIN_ADDRESS>Москва, Рязанский переулок, д. 13, стр. 1</STATION_BEGIN_ADDRESS>
+        <STATION_END_NAME>Санкт-Петербург</STATION_END_NAME>
+        <STATION_END_ADDRESS>м. Купчино </STATION_END_ADDRESS>
+        <RESERVATION_ENABLED>true</RESERVATION_ENABLED>
+        <SALE_ENABLED>true</SALE_ENABLED>
+        <RETURN_ENABLED>false</RETURN_ENABLED>
+        <TIME_FOR_CANCEL>25</TIME_FOR_CANCEL>
+        <TRIP_FULL_SALE>false</TRIP_FULL_SALE>
+        <CAN_DISCOUNT>true</CAN_DISCOUNT>
+        <INTERNATIONAL>false</INTERNATIONAL>
+        <JOIN_BOOK_BUY>false</JOIN_BOOK_BUY>
+        <TRIP_MODE>1</TRIP_MODE>
+        <CUSTOM_STATUS>0</CUSTOM_STATUS>
+        <IMAGE_URL>null</IMAGE_URL>
+        <START_POINT_TYPE>null</START_POINT_TYPE>
+        <FAKE_TIME_IN_ROAD>true</FAKE_TIME_IN_ROAD>
+        <VEHICLE_DESCRIPTION>null</VEHICLE_DESCRIPTION>
+        <RECOMMENDED>true</RECOMMENDED>
+        <VEHICLE_FEATURES>null</VEHICLE_FEATURES>
+        <TOTAL_COST>1410.0</TOTAL_COST>
+        <CURRENCY>RUB</CURRENCY>
+        <CURRENCY_CODE>643</CURRENCY_CODE>
+        <REDIRECT_URL>http://example.com/123</REDIRECT_URL>
+        <TARIFF>
+            <SHORT_NAME>Y</SHORT_NAME>
+            <FULL_NAME/>
+            <START_DATE/>
+            <END_DATE/>
+            <DESCRIPTION/>
+            <TIME_TO_BUY_RESERVED>0</TIME_TO_BUY_RESERVED>
+            <TIME_TO_STOP_BOOKING>0</TIME_TO_STOP_BOOKING>
+            <COST>1410</COST>
+            <AFTER_DISPATCH_NO_RETURN>false</AFTER_DISPATCH_NO_RETURN>
+            <PASSENGER_BIRTHDAY/>
+            <PASSENGER_ISIC_NUMBER/>
+            <PASSENGER_STUDENT_TICKET/>
+            <RETURN_CAUSE lossless='true'>cause 1</RETURN_CAUSE>
+            <RETURN_CAUSE id='asdasd'>cause 2</RETURN_CAUSE>
+            <RETURN_CAUSE>cause 3</RETURN_CAUSE>
+        </TARIFF>
+        <POINT>
+            <NUMBER>0</NUMBER>
+            <GEOGRAPHY_NAME>Москва</GEOGRAPHY_NAME>
+            <NAME>Москва</NAME>
+            <ADDRESS>Москва, Рязанский переулок, д. 13, стр. 1</ADDRESS>
+            <ARRIVAL_DATE>23.08.2014</ARRIVAL_DATE>
+            <ARRIVAL_TIME>19:00</ARRIVAL_TIME>
+            <DISPATCH_DATE/>
+            <DISPATCH_TIME/>
+            <CHECK_POINT>false</CHECK_POINT>
+        </POINT>
+        <POINT>
+            <NUMBER>1</NUMBER>
+            <GEOGRAPHY_NAME>Вышний Волочек</GEOGRAPHY_NAME>
+            <NAME>Вышний Волочек</NAME>
+            <ADDRESS>трасса (М10)</ADDRESS>
+            <ARRIVAL_DATE>24.08.2014</ARRIVAL_DATE>
+            <ARRIVAL_TIME>00:00</ARRIVAL_TIME>
+            <DISPATCH_DATE/>
+            <DISPATCH_TIME/>
+            <CHECK_POINT>false</CHECK_POINT>
+        </POINT>
+        <POINT>
+            <NUMBER>2</NUMBER>
+            <GEOGRAPHY_NAME>Великий Новгород</GEOGRAPHY_NAME>
+            <NAME>Великий Новгород</NAME>
+            <ADDRESS>трасса (Подберезье, поворот на Великий Новгород)</ADDRESS>
+            <ARRIVAL_DATE>24.08.2014</ARRIVAL_DATE>
+            <ARRIVAL_TIME>03:30</ARRIVAL_TIME>
+            <DISPATCH_DATE/>
+            <DISPATCH_TIME/>
+            <CHECK_POINT>false</CHECK_POINT>
+        </POINT>
+        <POINT>
+            <NUMBER>3</NUMBER>
+            <GEOGRAPHY_NAME>Санкт-Петербург</GEOGRAPHY_NAME>
+            <NAME>Санкт-Петербург</NAME>
+            <ADDRESS>м. Купчино </ADDRESS>
+            <ARRIVAL_DATE>24.08.2014</ARRIVAL_DATE>
+            <ARRIVAL_TIME>06:30</ARRIVAL_TIME>
+            <DISPATCH_DATE/>
+            <DISPATCH_TIME/>
+            <CHECK_POINT>false</CHECK_POINT>
+        </POINT>
+        <OPTIONS>
+            <TRIP_SERVICES>
+                <TRIP_SERVICE ID="1">Кофе</TRIP_SERVICE>
+                <TRIP_SERVICE ID="15">Wi-Fi</TRIP_SERVICE>
+            </TRIP_SERVICES>
+            <LUGGAGE>
+                <LUGGAG ID="1">В стоимость входит провоз 2 единиц багажа свыше 80 кг.</LUGGAG>
+                <LUGGAG ID="2">Ручная кладь 20см x 40см x 30см входит в стоимость билета.</LUGGAG>
+                <LUGGAG ID="3">Превышение по багажу оплачивается в размере 1% от стоимости тарифа.</LUGGAG>
+            </LUGGAGE>
+            <TECHNICAL_STOP>
+                <TECHNICAL_STO ID="1">Технические остановки осуществляются каждые 2-3 часа.</TECHNICAL_STO>
+            </TECHNICAL_STOP>
+            <CRITICAL_INFO>
+                <CRITICAL_INF ID="1">ВНИМАНИЕ: Особые условия паспортного режима пересечения пропускного пункта (только с паспортами РБ и РФ).</CRITICAL_INF>
+            </CRITICAL_INFO>
+            <SEATING>
+                <SEATIN ID="1">Свободная рассадка.</SEATIN>
+            </SEATING>
+            <RESOURCE_TRIP_OPTION>
+                <RESOURCE_TRIP_OPTIO ID="1">Посадка начинается за 10 мин.</RESOURCE_TRIP_OPTIO>
+            </RESOURCE_TRIP_OPTION>
+            <OTHER>
+                <OTHE ID="1">Переправа</OTHE>
+                <OTHE ID="2">Трансфер</OTHE>
+                <OTHE>Cкидка при покупке раунд-трипа</OTHE>
+            </OTHER>
+            <PROMO>
+                <PROM ID="1">BUSFOR_RECOMMEND</PROM>
+                <PROM ID="2">ADVERTISING</PROM>
+            </PROMO>
+            <TICKETS>
+                <TICKET ID="7">ЭЛЕКТРОННЫЙ БИЛЕТ. Печать билета не требуется!</TICKET>
+            </TICKETS>
+        </OPTIONS>
+    </TRIP>
+    <TRIP>
+        <ID>-3986171261205069729</ID>
+        <RES_ID>10</RES_ID>
+        <NUMBER>2093</NUMBER>
+        <START_CITY_NAME>Москва</START_CITY_NAME>
+        <END_CITY_NAME>Санкт-Петербург</END_CITY_NAME>
+        <START_DATE>23.08.2014</START_DATE>
+        <END_DATE>24.08.2014</END_DATE>
+        <START_TIME>21:10</START_TIME>
+        <END_TIME>08:40</END_TIME>
+        <BUS_MODEL/>
+        <PLACES_COUNT>18</PLACES_COUNT>
+        <FREE_PLACES_COUNT>10</FREE_PLACES_COUNT>
+        <FREE_BUSY_PLACES>10/18</FREE_BUSY_PLACES>
+        <CARRIER_NAME>ИП Унанян И.А.</CARRIER_NAME>
+        <TIME_IN_ROAD>11:30</TIME_IN_ROAD>
+        <STATION_BEGIN_NAME>Москва</STATION_BEGIN_NAME>
+        <STATION_BEGIN_ADDRESS>Москва, Рязанский переулок, д. 13, стр. 1</STATION_BEGIN_ADDRESS>
+        <STATION_END_NAME>Санкт-Петербург</STATION_END_NAME>
+        <STATION_END_ADDRESS>м. Купчино </STATION_END_ADDRESS>
+        <RESERVATION_ENABLED>true</RESERVATION_ENABLED>
+        <SALE_ENABLED>true</SALE_ENABLED>
+        <RETURN_ENABLED>false</RETURN_ENABLED>
+        <TIME_FOR_CANCEL>25</TIME_FOR_CANCEL>
+        <TRIP_FULL_SALE>false</TRIP_FULL_SALE>
+        <CAN_DISCOUNT>true</CAN_DISCOUNT>
+        <INTERNATIONAL>false</INTERNATIONAL>
+        <JOIN_BOOK_BUY>false</JOIN_BOOK_BUY>
+        <RECOMMENDED>false</RECOMMENDED>
+        <TRIP_MODE>1</TRIP_MODE>
+        <CUSTOM_STATUS>0</CUSTOM_STATUS>
+        <IMAGE_URL>null</IMAGE_URL>
+        <START_POINT_TYPE>null</START_POINT_TYPE>
+        <VEHICLE_DESCRIPTION>null</VEHICLE_DESCRIPTION>
+        <VEHICLE_FEATURES>null</VEHICLE_FEATURES>
+        <TOTAL_COST>1410</TOTAL_COST>
+        <CURRENCY>RUB</CURRENCY>
+        <CURRENCY_CODE>643</CURRENCY_CODE>
+        <TARIFF>
+            <SHORT_NAME>Y</SHORT_NAME>
+            <FULL_NAME/>
+            <START_DATE/>
+            <END_DATE/>
+            <DESCRIPTION/>
+            <TIME_TO_BUY_RESERVED>0</TIME_TO_BUY_RESERVED>
+            <TIME_TO_STOP_BOOKING>0</TIME_TO_STOP_BOOKING>
+            <COST>1410</COST>
+            <AFTER_DISPATCH_NO_RETURN>false</AFTER_DISPATCH_NO_RETURN>
+            <PASSENGER_BIRTHDAY/>
+            <PASSENGER_ISIC_NUMBER/>
+            <PASSENGER_STUDENT_TICKET/>
+            <RETURN_CAUSE id='asdasd'>cause 1</RETURN_CAUSE>
+            <IS_EXCLUSIVE_PRICE>true</IS_EXCLUSIVE_PRICE>
+        </TARIFF>
+        <POINT>
+            <NUMBER>0</NUMBER>
+            <GEOGRAPHY_NAME>Москва</GEOGRAPHY_NAME>
+            <NAME>Москва</NAME>
+            <ADDRESS>Москва, Рязанский переулок, д. 13, стр. 1</ADDRESS>
+            <ARRIVAL_DATE>23.08.2014</ARRIVAL_DATE>
+            <ARRIVAL_TIME>21:10</ARRIVAL_TIME>
+            <DISPATCH_DATE/>
+            <DISPATCH_TIME/>
+            <CHECK_POINT>false</CHECK_POINT>
+        </POINT>
+        <POINT>
+            <NUMBER>1</NUMBER>
+            <GEOGRAPHY_NAME>Вышний Волочек</GEOGRAPHY_NAME>
+            <NAME>Вышний Волочек</NAME>
+            <ADDRESS>трасса (М10)</ADDRESS>
+            <ARRIVAL_DATE>24.08.2014</ARRIVAL_DATE>
+            <ARRIVAL_TIME>02:10</ARRIVAL_TIME>
+            <DISPATCH_DATE/>
+            <DISPATCH_TIME/>
+            <CHECK_POINT>false</CHECK_POINT>
+        </POINT>
+        <POINT>
+            <NUMBER>2</NUMBER>
+            <GEOGRAPHY_NAME>Великий Новгород</GEOGRAPHY_NAME>
+            <NAME>Великий Новгород</NAME>
+            <ADDRESS>трасса (Подберезье, поворот на Великий Новгород)</ADDRESS>
+            <ARRIVAL_DATE>24.08.2014</ARRIVAL_DATE>
+            <ARRIVAL_TIME>05:40</ARRIVAL_TIME>
+            <DISPATCH_DATE/>
+            <DISPATCH_TIME/>
+            <CHECK_POINT>false</CHECK_POINT>
+        </POINT>
+        <POINT>
+            <NUMBER>3</NUMBER>
+            <GEOGRAPHY_NAME>Санкт-Петербург</GEOGRAPHY_NAME>
+            <NAME>Санкт-Петербург</NAME>
+            <ADDRESS>м. Купчино </ADDRESS>
+            <ARRIVAL_DATE>24.08.2014</ARRIVAL_DATE>
+            <ARRIVAL_TIME>08:40</ARRIVAL_TIME>
+            <DISPATCH_DATE/>
+            <DISPATCH_TIME/>
+            <CHECK_POINT>false</CHECK_POINT>
+        </POINT>
+        <OPTIONS>
+        </OPTIONS>
+    </TRIP>
+</DATA>

--- a/test/search_trips_test.rb
+++ b/test/search_trips_test.rb
@@ -53,6 +53,10 @@ class SearchTripsResponseTest < Minitest::Test
     Gillbus::SearchTrips::Response.parse_string(File.read('test/responses/searchTrips-prod.xml'))
   end
 
+  def get_successful_search_trips_with_new_options_format
+    Gillbus::SearchTrips::Response.parse_string(File.read('test/responses/searchTrips-new-options-format.xml'))
+  end
+
   def get_successful_search_trips_with_bad_data
     Gillbus::SearchTrips::Response.parse_string(File.read('test/responses/searchTrips-prod-invalid.xml'))
   end
@@ -122,6 +126,55 @@ class SearchTripsResponseTest < Minitest::Test
 
   def test_options_parsing
     response = get_successful_search_trips
+    options = response.trips.first.options
+
+    services = {
+      1 => 'Кофе',
+      15 => 'Wi-Fi',
+    }
+    luggage_options = [
+      'В стоимость входит провоз 2 единиц багажа свыше 80 кг.',
+      'Ручная кладь 20см x 40см x 30см входит в стоимость билета.',
+      'Превышение по багажу оплачивается в размере 1% от стоимости тарифа.',
+    ]
+    seating_options = [
+      'Свободная рассадка.',
+    ]
+    technical_stops = [
+      'Технические остановки осуществляются каждые 2-3 часа.',
+    ]
+    critical_info = [
+      'ВНИМАНИЕ: Особые условия паспортного режима пересечения пропускного пункта (только с паспортами РБ и РФ).',
+    ]
+    resource_options = [
+      'Посадка начинается за 10 мин.',
+    ]
+    other_options = [
+      'Переправа',
+      'Трансфер',
+      'Cкидка при покупке раунд-трипа',
+    ]
+    titckets_options = [
+      'ЭЛЕКТРОННЫЙ БИЛЕТ. Печать билета не требуется!',
+    ]
+    titckets_options_ids = [7]
+
+    assert_equal services.values, options.services.map(&:name)
+    assert_equal services.keys, options.services.map(&:id)
+    assert_equal luggage_options, options.luggage
+    assert_equal seating_options, options.seating
+    assert_equal technical_stops, options.technical_stops
+    assert_equal critical_info, options.critical_info
+    assert_equal resource_options, options.resource_options
+    assert_equal other_options, options.other
+    assert_equal titckets_options, options.tickets.map(&:text)
+    assert_equal titckets_options_ids, options.tickets.map(&:id)
+    assert options.advertising
+    assert options.busfor_recommend
+  end
+
+  def test_new_options_format
+    response = get_successful_search_trips_with_new_options_format
     options = response.trips.first.options
 
     services = {


### PR DESCRIPTION
Поддержка изменений со стороны GDS:

> В тэг описывающем опции <OPTIONS> теперь наименование тэгов содержащих название опции будет не ITEM, а название будет формироваться из названия родительского тэга (-1 последний символ) и добавляться id опции.

Поддержаны оба формата для возможности плавного перехода.