### PR TITLE
BSRWEB-4694 always send `Host` http header

### DIFF
--- a/lib/gillbus.rb
+++ b/lib/gillbus.rb
@@ -28,6 +28,7 @@ class Gillbus
       headers = {}
       headers['Cookie'] = self.class.make_cookies(session_id) if session_id
       headers['Accept-Encoding'] = 'gzip'
+      headers['Host'] = driver.host
       request_time_start = Time.now
       http_response = driver.public_send(request.method, request.path, request.params, headers)
       request_time_end = Time.now

--- a/lib/gillbus/version.rb
+++ b/lib/gillbus/version.rb
@@ -1,3 +1,3 @@
 class Gillbus
-  VERSION = '0.20.0'.freeze
+  VERSION = '0.20.1'.freeze
 end


### PR DESCRIPTION
> Команда GDS сообщила что мы при запросе к API не передаем заголовок Host с доменом инстанса GDS к которому мы обращаемся.
В результате им приходится костылить настройки своего балансировщика и заводить лишние серверы.

>Нужно понять почему мы не передаем этот заголовок?
Включить передачу заголовка Host в запрос.
